### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -12,3 +12,19 @@ p6df::modules::sudo::deps() {
         ohmyzsh/ohmyzsh:plugins/sudo
     )
 }
+
+######################################################################
+#<
+#
+# Function: words sudo $SUDO_UID = p6df::modules::sudo::profile::mod()
+#
+#  Returns:
+#	words - sudo $SUDO_UID
+#
+#  Environment:	 SUDO_UID
+#>
+######################################################################
+p6df::modules::sudo::profile::mod() {
+
+  p6_return_words 'sudo' '$SUDO_UID'
+}

--- a/init.zsh
+++ b/init.zsh
@@ -26,5 +26,5 @@ p6df::modules::sudo::deps() {
 ######################################################################
 p6df::modules::sudo::profile::mod() {
 
-  p6_return_words 'sudo' '$SUDO_UID'
+  p6_return_words 'sudo' "$SUDO_UID"
 }


### PR DESCRIPTION
## What
Refactor prompt module with all local changes including p6_return_words quoting fix.

## Why
Split p6_return_words word and variable into separate quoted args; also includes related prompt/profile refactors.

## Test plan
- Verified diff contains expected changes

## Dependencies
None