### PR TITLE
fix(sudo): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -26,5 +26,5 @@ p6df::modules::sudo::deps() {
 ######################################################################
 p6df::modules::sudo::profile::mod() {
 
-  p6_return_words 'sudo' "$SUDO_UID"
+  p6_return_words 'sudo' '$SUDO_UID'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None